### PR TITLE
navbar 컴포넌트 수정

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { ReactComponent as ComplimentImg } from "../images/compliment.svg";
 import { ReactComponent as GatheringImg } from "../images/gathering.svg";
 import { ReactComponent as MemberImg } from "../images/member.svg";
@@ -11,12 +12,14 @@ interface Props {
 };
 
 const Navbar = ({state = 1}: Props) => {
+    const navigate = useNavigate();
 
     // navbar의 순서대로 1, 2, 3, 4라는 숫자 부여
     const [check, setCheck] = useState<number>(state);
 
     const handleComplimentImgClick = () => {
         setCheck(1);
+        navigate('/home');
     };
 
     const handleGatheringImgClick = () => {
@@ -25,6 +28,7 @@ const Navbar = ({state = 1}: Props) => {
 
     const handleMemberImgClick = () => {
         setCheck(3);
+        navigate('/member-list');
     };
 
     const handleMyImgClick = () => {
@@ -35,7 +39,8 @@ const Navbar = ({state = 1}: Props) => {
         <>
             <div style={{ padding: '0 20px 0 20px', height: '49px',
                         borderTop: '0.5px solid var(--surface-outline, rgba(10, 10, 10, 0.10))',
-                        position: 'sticky', bottom: '0px', backgroundColor: 'white',
+                        backgroundColor: 'white', width: "100%", maxWidth: "500px",
+                        position: 'fixed', boxSizing: "border-box", bottom: '0px',
                         display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between'
             }}>
                 <div


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#16, navbar 컴포넌트 페이지 이동 및 화면 상 위치 수정

## 작업 내용 (변경 사항)
issue의 코멘트대로 position요소를 sticky에서 fixed로 변경하고 그에 대한 코드 약간 수정
navbar 요소 클릭 시 현재 이동 가능한 페이지로 이동 가능하게 코드 수정

## 리뷰 요청 사항
모바일 화면은 괜찮은데 컴퓨터에서는 옆에 스크롤바가 있느냐 없느냐에 따라서 navbar 전체가 약간 움직이는 문제 발생 이에 대해 해결 방법을 아직 생각 못해서 아는 사항 있으면 코멘트 남겨주시면 감사하겠습니다.
그리고 member-list 페이지의 원형 이미지가 헤더보다 zindex가 높아 보이는데 헤더에서 수정해야 되는지 원형 이미지에서 수정해야 되는 지에 대한 생각도 남겨주시면 감사하겠습니다.