### PR TITLE
다중 버튼 컴포넌트 추가

### DIFF
--- a/src/components/ButtonMultiple.tsx
+++ b/src/components/ButtonMultiple.tsx
@@ -1,0 +1,69 @@
+import { color } from "../styles/color";
+import { typography } from "../styles/typography";
+
+interface OwnProps {
+  textList: string[];
+  onClickList: React.MouseEventHandler<HTMLButtonElement>[];
+  closeHandler: React.MouseEventHandler<HTMLDivElement>;
+}
+
+const ButtonMultiple = ({ textList, onClickList, closeHandler }: OwnProps) => {
+  if (textList.length !== onClickList.length)
+    console.error("버튼의 개수와 핸들러 함수의 개수가 일치하지 않습니다.");
+  return (
+    <>
+      <div
+        onClick={closeHandler}
+        style={{
+          position: "fixed",
+          top: "0",
+          left: "0",
+          right: "0",
+          bottom: "0",
+          backgroundColor: "rgba(0,0,0,0.5)",
+          zIndex: "1",
+        }}
+      ></div>
+      <div
+        style={{
+          position: "fixed",
+          width: "calc(100% - 40px)",
+          margin: "0 auto",
+          maxWidth: "460px",
+          left: "0",
+          right: "0",
+          bottom: "33px",
+          zIndex: "2",
+          display: "flex",
+          flexDirection: "column",
+          gap: "6px",
+        }}
+      >
+        {textList.map((item, index) => {
+          return (
+            <button
+              style={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                height: "47px",
+                color: `${color.onSurfaceDefault}`,
+                backgroundColor: `${color.surface}`,
+                ...typography.body1Medium,
+                padding: "0",
+                border: "none",
+                borderRadius: "8px",
+                fontFamily: "Pretendard",
+              }}
+              onClick={onClickList[index]}
+            >
+              {item}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default ButtonMultiple;


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#6 다중버튼 컴포넌트 추가

## 작업 내용 (변경 사항)
버튼에 들어갈 문구를 string[] 타입으로 받고
각 버튼 별 handler 함수를 배열로 받음
추가로 회색 화면을 눌렀을 때 closeHandler를 받는데,
주로 마지막 버튼인 취소 버튼의 handler와 동일한 함수를 입력하면 됨

textList의 길이와 onClickList의 길이가 다를 경우 에러 출력

- 사용예시
![image](https://github.com/Manna-voca/zenga-frontend/assets/54929509/9ba8e42d-1229-4957-a431-f2fa897bd52c)

## 리뷰 요청 사항
실제 페이지에서 사용해보진 않아서 충돌생기는 부분있으면 이슈 re-open 부탁드립니다.
