### PR TITLE
api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
       <Route path="/create-channel" element={<CreateChannel />}></Route>
       <Route path="/create-channel/new-onboarding" element={<NewChannelOnboarding />}></Route>
       <Route path="/create-channel/old-onboarding" element={<OldChannelOnboarding />}></Route>
-      <Route path="/praise" element={<Praise />}></Route>
+      <Route path="/:channelCode/praise" element={<Praise />}></Route>
       <Route path="/member-list" element={<MemberList />}></Route>
       <Route path="/notification" element={<Notification />}></Route>
       <Route path="/create-meetup" element={<CreateMeetup />}></Route>

--- a/src/components/CircularImage.tsx
+++ b/src/components/CircularImage.tsx
@@ -36,6 +36,7 @@ const CircularImage: FC<CircularImageProps> = ({
         style={{
           borderRadius: "500px",
           display: "block",
+          objectFit: "cover"
         }}
       ></img>
       {isChannelAdmin && (

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -18,6 +18,8 @@ interface DatePickerProps {
   isNecessary: boolean;
   placeholder: string;
   value: string;
+  birthDate: string;
+  setBirthDate: react.Dispatch<react.SetStateAction<string>>
 }
 
 const DatePicker: FC<DatePickerProps> = ({
@@ -25,16 +27,17 @@ const DatePicker: FC<DatePickerProps> = ({
   isNecessary,
   placeholder,
   value,
+  birthDate,
+  setBirthDate,
 }) => {
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
-  const [birthDate, setBirthDate] = useState<string>();
 
   const handleDateChange = (date: Date) => {
     const formatDatetoString = (birthDate: Date) => {
       const year = birthDate.getFullYear();
       const month = (birthDate.getMonth() + 1).toString().padStart(2, "0");
       const date = birthDate.getDate().toString().padStart(2, "0");
-      return `${year}/${month}/${date}`;
+      return `${year}.${month}.${date}`;
     };
     setBirthDate(formatDatetoString(date));
   };
@@ -93,7 +96,6 @@ const DatePicker: FC<DatePickerProps> = ({
           showMonthDropdown
           showYearDropdown
           dropdownMode="select"
-          dateFormat="yyyy.MM.dd"
         />
         <img
           style={{

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -19,7 +19,7 @@ interface DatePickerProps {
   placeholder: string;
   value: string;
   birthDate: string;
-  setBirthDate: react.Dispatch<react.SetStateAction<string>>
+  setBirthDate: react.Dispatch<react.SetStateAction<string>>;
 }
 
 const DatePicker: FC<DatePickerProps> = ({
@@ -81,22 +81,37 @@ const DatePicker: FC<DatePickerProps> = ({
       </div>
 
       <div style={{ position: "relative", width: "100%" }}>
-        <StyledDatePicker
-          onCalendarClose={() => setIsSelecting((prev) => !prev)}
-          onCalendarOpen={() => {
-            setIsSelecting((prev) => !prev);
-          }}
-          title=""
-          locale={ko}
-          onChange={handleDateChange}
-          value={birthDate}
-          placeholderText={placeholder}
-          required
-          onFocus={(e) => e.target.blur()}
-          showMonthDropdown
-          showYearDropdown
-          dropdownMode="select"
-        />
+        {isSelecting && (
+          <div
+            style={{
+              zIndex: "1",
+              position: "fixed",
+              background: "rgba(0,0,0,0.50)",
+              width: "100%",
+              height: "100%",
+              top: "0",
+              left: "0",
+            }}
+          />
+        )}
+        <div style={{ position: "relative", zIndex: "2" }}>
+          <StyledDatePicker
+            onCalendarClose={() => setIsSelecting((prev) => !prev)}
+            onCalendarOpen={() => {
+              setIsSelecting((prev) => !prev);
+            }}
+            title=""
+            locale={ko}
+            onChange={handleDateChange}
+            value={birthDate}
+            placeholderText={placeholder}
+            required
+            onFocus={(e) => e.target.blur()}
+            showMonthDropdown
+            showYearDropdown
+            dropdownMode="select"
+          />
+        </div>
         <img
           style={{
             cursor: "pointer",
@@ -110,18 +125,6 @@ const DatePicker: FC<DatePickerProps> = ({
           alt=""
         />
       </div>
-      {isSelecting && (
-        <div
-          style={{
-            position: "fixed",
-            background: "rgba(0,0,0,0.50)",
-            width: "100%",
-            height: "100%",
-            top: "0",
-            left: "0",
-          }}
-        />
-      )}
     </div>
   );
 };

--- a/src/components/DropDown.tsx
+++ b/src/components/DropDown.tsx
@@ -108,9 +108,10 @@ const DropDown: FC<DropDownProps> = ({
           }}
         >
           {isSelecting &&
-            dropdownMenu.map((item) => {
+            dropdownMenu.map((item, index) => {
               return (
                 <div
+                  key={index}
                   onClick={() => {
                     onChange(item);
                     setIsSelecting((prev) => !prev);

--- a/src/components/MemberWrapper.tsx
+++ b/src/components/MemberWrapper.tsx
@@ -8,14 +8,15 @@ import { useNavigate } from "react-router-dom";
 
 interface OwnProps {
   name: string;
+  id: number;
   image: string;
   isChannelAdmin: boolean;
 }
 
-const MemberWrapper = ({ name, image, isChannelAdmin }: OwnProps) => {
+const MemberWrapper = ({ name, image, id, isChannelAdmin }: OwnProps) => {
   const navigate = useNavigate();
   return (
-    <Container onClick={() => navigate('/memberpage/1')}>
+    <Container onClick={() => navigate("/memberpage/1")}>
       <CircularImage
         image={image}
         size="36"

--- a/src/components/Popup2.tsx
+++ b/src/components/Popup2.tsx
@@ -29,23 +29,29 @@ const Popup2 = ({title, text, leftBtnText, rightBtnText, leftFunc, rightFunc}: P
                 }}>
             </div>
             <div
+                style={{ position: 'fixed', top: '50%', left: "50%", transform: "translate(-50%,-50%)", width: 'calc(100vw - 25px)',
+                        margin: '0', backgroundColor: 'white',
+                        height: '187px', borderRadius: '8px',
+                        display: 'flex', justifyContent: 'center',
+                        zIndex: '3', maxWidth: 'calc(500px - 25px)'
+            }}>
+            {/* <div
                 style={{ position: 'fixed', top: '269px', width: 'calc(100vw - 25px)',
                         margin: '0 12px 0 13px', backgroundColor: 'white',
                         height: '187px', borderRadius: '8px',
                         display: 'flex', justifyContent: 'center',
                         zIndex: '3', maxWidth: 'calc(500px - 25px)'
-            }}>
+            }}> */}
                 <div
                     style={{ margin: '28px 0 16px 0', display: 'flex',
                             flexDirection: 'column', alignItems: 'center',
-                            width: '100%'
+                            width: '100%',
                 }}>
                     <div
                         style={{ height: '27px', fontSize: '16px',
                                 fontStyle: 'normal', fontWeight: '700',
                                 lineHeight: '150%', display: 'flex',
                                 justifyContent: 'center', alignItems: 'center'
-
                     }}>
                         <span>{title}</span>
                     </div>

--- a/src/components/PraiseContainer.tsx
+++ b/src/components/PraiseContainer.tsx
@@ -1,7 +1,12 @@
+/** @jsxImportSource @emotion/react */
+import { css, keyframes } from "@emotion/react";
 import styled from "@emotion/styled";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import PraiseWrapper from "./PraiseWrapper";
-import ex from "../assets/images/profile-1.png";
+import axios from "axios";
+import { color } from "../styles/color";
+import whaleCharacter7 from "../assets/images/whale_character7.png";
+import Popup2 from "./Popup2";
 
 interface OwnProps {
   isGetNotPost: boolean;
@@ -15,81 +20,116 @@ interface PraiseProps {
 }
 
 const PraiseContainer = ({ isGetNotPost }: OwnProps) => {
-  const getPraiseDummy: Array<PraiseProps> = [
-    {
-      content: "항상 일순위로 먼저 도전할 것 같은 사람은? ",
-      name: "익명",
-      type: "Yellow",
+  const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  const CONFIG = {
+    headers: {
+      // Authorization: "Bearer " + localStorage.getItem("accessToken"),
+      Authorization:
+        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI",
     },
+  };
+  const CHANNEL_ID = localStorage.getItem("channelId");
+  const [isLoading, setIsLoading] = useState(true);
+  const [newPraiseOpened, setNewPraiseOpened] = useState(false);
+
+  const blockColor = (praiseType: string) => {
+    switch (praiseType) {
+      case "OTHERS":
+        return "Blue";
+      case "PASSION":
+        return "Yellow";
+      case "APPEARANCE":
+        return "Pink";
+      case "PERSONALITY":
+        return "Orange";
+      case "ABILITY":
+        return "Green";
+      default:
+        return "Default";
+    }
+  };
+
+  const [receivePraiseList, setReceivePraiseList] = useState([
     {
-      content: "가장 꺾이지 않는 마음을 가진 사람은? ",
-      name: "익명",
-      type: "Blue",
+      memberPraiseId: -1,
+      isOpened: false,
+      praiseDescription: "",
+      memberName: "",
+      memberProfileImageUrl: "",
+      praiseType: "",
     },
+  ]);
+  const [sendPraiseList, setSendPraiseList] = useState([
     {
-      content: "시험기간 밤샘을 가장 잘 할 것 같은 사람은? ",
-      name: "익명",
-      type: "Green",
+      memberPraiseId: -1,
+      praiseDescription: "",
+      memberName: "",
+      memberProfileImageUrl: "",
+      praiseType: "",
+      isOpened: true,
     },
-    {
-      content: "우리 동아리에서 가장 눈치가 빠른 사람은? ",
-      name: "익명",
-      type: "Purple",
-    },
-    {
-      content: "시험기간 밤샘 카공 같이 하고 싶은 사람은? ",
-      name: "익명",
-      type: "Orange",
-    },
-  ];
-  const postPraiseDummy: Array<PraiseProps> = [
-    {
-      content: "항상 일순위로 먼저 도전할 것 같은 사람은? ",
-      image: ex,
-      name: "윤석민",
-      type: "Yellow",
-    },
-    {
-      content: "가장 꺾이지 않는 마음을 가진 사람은? ",
-      image: ex,
-      name: "김민근",
-      type: "Blue",
-    },
-    {
-      content: "시험기간 밤샘을 가장 잘 할 것 같은 사람은? ",
-      image: ex,
-      name: "박세원",
-      type: "Green",
-    },
-    {
-      content: "우리 동아리에서 가장 눈치가 빠른 사람은? ",
-      image: ex,
-      name: "송현섭",
-      type: "Purple",
-    },
-    {
-      content: "시험기간 밤샘 카공 같이 하고 싶은 사람은? ",
-      image: ex,
-      name: "유승민",
-      type: "Orange",
-    },
-  ];
-  const praiseDummy = isGetNotPost ? getPraiseDummy : postPraiseDummy;
+  ]);
+
+  const praiseList = isGetNotPost ? receivePraiseList : sendPraiseList;
+
+  const fetchPraiseData = async () => {
+    try {
+      if (isGetNotPost === true) {
+        const res = await axios.get(
+          `${SERVER_URL}/praise/receive?channelId=${CHANNEL_ID}`,
+          CONFIG
+        );
+        setReceivePraiseList(res.data.data.content);
+      } else {
+        const res = await axios.get(
+          `${SERVER_URL}/praise/send?channelId=${CHANNEL_ID}`,
+          CONFIG
+        );
+        setSendPraiseList(res.data.data.content);
+      }
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchPraiseData().then(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    fetchPraiseData().then(() => setIsLoading(false));
+  }, [newPraiseOpened])
 
   return (
     <PraiseContainerDiv>
-      {praiseDummy.map((praise, index) => {
-        return (
-          <PraiseWrapper
-            key={index}
-            isGetNotPost={isGetNotPost}
-            content={praise.content}
-            image={praise.image}
-            name={praise.name}
-            type={praise.type}
-          />
-        );
-      })}
+      {isLoading ? (
+        <LoadingDiv>
+          <LoadingSpinner />
+        </LoadingDiv>
+      ) : praiseList.length === 0 ? (
+        <div css={inactiveCategoryDivStyle}>
+          <img width="72px" src={whaleCharacter7} alt="" />
+          <span css={inactiveCategorySpanStyle}>
+            아직 <b>{isGetNotPost ? "받은" : "보낸"} 칭찬</b>이 없어요
+          </span>
+        </div>
+      ) : (
+        praiseList.map((praise, index) => {
+          return (
+            <PraiseWrapper
+              handlePraiseOpen={() => setNewPraiseOpened(prev => !prev)}
+              praiseId={praise.memberPraiseId}
+              key={index}
+              isGetNotPost={isGetNotPost}
+              content={praise.praiseDescription}
+              image={praise.memberProfileImageUrl}
+              name={praise.memberName}
+              type={blockColor(praise.praiseType)}
+              isOpened={praise.isOpened}
+            />
+          );
+        })
+      )}
     </PraiseContainerDiv>
   );
 };
@@ -100,6 +140,43 @@ const PraiseContainerDiv = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 0 20px;
+  padding: 0 20px 60px;
   margin-top: 20px;
+`;
+
+const LoadingDiv = styled.div`
+  height: 113px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+const LoadingSpinner = styled.div`
+  width: 20px;
+  height: 20px;
+  border: 3px solid ${color.surface};
+  border-top-color: ${color.primary300};
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+`;
+const inactiveCategoryDivStyle = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 120px;
+  gap: 20px;
+`;
+
+const inactiveCategorySpanStyle = css`
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: ${color.onSurfaceActive};
+  text-align: center;
 `;

--- a/src/components/SendPraise.tsx
+++ b/src/components/SendPraise.tsx
@@ -25,12 +25,13 @@ import "swiper/css/pagination";
 import "../styles/sendpraiseSwiper.css";
 import whaleClock from "../assets/images/whale-clock.png";
 import sendPraiseModalImage from "../assets/images/sendPraiseModal.png";
+import axios from "axios";
+import { useParams, useNavigate } from "react-router-dom";
 
 interface MemberProps {
   name: string;
-  profileImage: string;
-  isChannelAdmin: boolean;
-  userId: number;
+  profileImageUrl: string;
+  memberId: number;
 }
 
 interface PraiseMemberWrapperProps extends MemberProps {
@@ -46,9 +47,8 @@ interface PraiseProps {
 
 const PraiseMemberWrapper = ({
   name,
-  profileImage,
-  isChannelAdmin,
-  userId,
+  profileImageUrl: profileImage,
+  memberId: userId,
   selectedMember,
   onClick,
 }: PraiseMemberWrapperProps) => {
@@ -60,7 +60,7 @@ const PraiseMemberWrapper = ({
         display: "flex",
         width: "275px",
         height: "48px",
-        padding: "6px",
+        padding: "6px 40px 6px 6px",
         boxSizing: "border-box",
         border: selected
           ? `2px solid ${color.secondary500}`
@@ -68,20 +68,19 @@ const PraiseMemberWrapper = ({
         backgroundColor: selected
           ? `${color.secondary50}`
           : `${color.background}`,
-        gap: "74px",
+        gap: "8px",
         alignItems: "center",
         borderRadius: "100px",
         cursor: "pointer",
       }}
     >
-      <CircularImage
-        image={profileImage}
-        size="36"
-      />
+      <CircularImage image={profileImage} size="36" />
       <span
         style={{
           color: `${color.onSurfaceActive}`,
           ...typography.heading4Regular,
+          flexGrow: "1",
+          textAlign: "center",
         }}
       >
         {name}
@@ -307,50 +306,125 @@ const FirstModal = ({
 };
 
 const SendPraise = () => {
-  const [praiseInfo, setPraiseInfo] = useState<PraiseProps>({
-    content: "내 인생의 절반을 줄테니 네 인생의 절반을 줘..",
-    members: [
-      { name: "박세원", profileImage: ex, isChannelAdmin: false, userId: 1 },
-      { name: "송현섭", profileImage: ex, isChannelAdmin: false, userId: 2 },
-      { name: "김민근", profileImage: ex, isChannelAdmin: false, userId: 3 },
-      { name: "유승민", profileImage: ex, isChannelAdmin: false, userId: 4 },
-      { name: "윤석민", profileImage: ex, isChannelAdmin: true, userId: 5 },
-      { name: "변지현", profileImage: ex, isChannelAdmin: false, userId: 6 },
-      { name: "송예지", profileImage: ex, isChannelAdmin: false, userId: 7 },
-      { name: "김수한무", profileImage: ex, isChannelAdmin: false, userId: 8 },
+  const { channelCode } = useParams();
+  const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  const CONFIG = {
+    headers: {
+      // Authorization: "Bearer " + localStorage.getItem("accessToken"),
+      Authorization:
+        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI",
+    },
+  };
+  const [praiseInfo, setPraiseInfo] = useState({
+    praise: "",
+    memberList: [
+      { name: "", profileImageUrl: "", memberId: 1 },
+      { name: "", profileImageUrl: "", memberId: 2 },
+      { name: "", profileImageUrl: "", memberId: 3 },
+      { name: "", profileImageUrl: "", memberId: 4 },
+      { name: "", profileImageUrl: "", memberId: 5 },
+      { name: "", profileImageUrl: "", memberId: 6 },
+      { name: "", profileImageUrl: "", memberId: 7 },
+      { name: "", profileImageUrl: "", memberId: 8 },
     ],
-    hasShuffled: false,
+    shuffleCount: 0,
+    memberPraiseId: 0,
   });
-  const start = praiseInfo.hasShuffled ? 4 : 0;
-  const end = praiseInfo.hasShuffled ? 8 : 4;
+
+  const fetchModalInfo = async () => {
+    try {
+      const res = await axios.get(
+        `${SERVER_URL}/members/modal/${localStorage.getItem("channelId")}`,
+        CONFIG
+      );
+      setShowFirstModal(res.data.data.praiseModal);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const fetchPraiseData = async () => {
+    try {
+      const res = await axios.post(
+        `${SERVER_URL}/praise/todo`,
+        { channelId: localStorage.getItem("channelId") },
+        CONFIG
+      );
+      if (res.data.data === null) {
+        setShowPraiseNotTimer(false);
+      } else {
+        setPraiseInfo(res.data.data);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchPraiseData();
+    fetchModalInfo();
+    // eslint-disable-next-line
+  }, []);
+
+  const start = praiseInfo.shuffleCount ? 4 : 0;
+  const end = praiseInfo.shuffleCount ? 8 : 4;
   const [selectedMember, setSelectedMember] = useState<number>(-1);
   const [showPraiseModal, setShowPraiseModal] = useState(false);
   const [showPraiseNotTimer, setShowPraiseNotTimer] = useState(true);
   const [showFirstModal, setShowFirstModal] = useState(true);
   const [firstModalNeverShow, setFirstModalNeverShow] = useState(false);
 
-  const firstModalCloseOnClick = () => {
-    if (firstModalNeverShow) {
-      // 다시보지않기 api 전송
-      console.log("다시보지않아 !");
+  const firstModalCloseOnClick = async () => {
+    try {
+      if (firstModalNeverShow) {
+        // 다시보지않기 api 전송
+        await axios.patch(
+          `${SERVER_URL}/members/modal/praise/${localStorage.getItem(
+            "channelId"
+          )}`,
+          {},
+          CONFIG
+        );
+      }
+      setShowFirstModal(false);
+    } catch (error) {
+      console.log(error);
     }
-    console.log("끄기")
-    setShowFirstModal(false);
   };
 
-  const handleShuffleClick = () => {
-    setPraiseInfo((prev) => ({
-      ...prev,
-      hasShuffled: !prev.hasShuffled, // 개발 후 false로 변경하고 shuffle Click 막아야 함
-    }));
-    setSelectedMember(-1);
+  const handleShuffleClick = async () => {
+    try {
+      setPraiseInfo((prev) => ({
+        ...prev,
+        shuffleCount: prev.shuffleCount === 1 ? 0 : 1, // 개발 후 false로 변경하고 shuffle Click 막아야 함
+      }));
+      setSelectedMember(-1);
+      await axios.patch(
+        `${SERVER_URL}/praise/todo`,
+        { channelId: localStorage.getItem("channelId") },
+        CONFIG
+      );
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   const handleSendPraise = async () => {
-    console.log(selectedMember);
-    setSelectedMember(-1);
     /* await 칭찬 api 함수 */
-    setShowPraiseModal(true);
+    try {
+      await axios.patch(
+        `${SERVER_URL}/praise/choice`,
+        {
+          memberPraiseId: praiseInfo.memberPraiseId,
+          praisedMemberId: selectedMember,
+        },
+        CONFIG
+      );
+      setSelectedMember(-1);
+      setShowPraiseModal(true);
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   const modalCloseAndShowTimer = () => {
@@ -362,12 +436,16 @@ const SendPraise = () => {
     <>
       {showPraiseNotTimer ? (
         <SendPraiseContainer>
-          <SendPraiseContent>{praiseInfo.content}</SendPraiseContent>
+          <SendPraiseContent>{praiseInfo.praise}</SendPraiseContent>
           <ShuffleButton
+            disabled={praiseInfo.shuffleCount === 1}
             onClick={handleShuffleClick}
             style={{
-              color: praiseInfo.hasShuffled ? `${color.onPrimaryDisabled}` : "",
-              borderColor: praiseInfo.hasShuffled
+              cursor: praiseInfo.shuffleCount === 1 ? "unset" : "pointer",
+              color: praiseInfo.shuffleCount
+                ? `${color.onPrimaryDisabled}`
+                : "",
+              borderColor: praiseInfo.shuffleCount
                 ? `${color.onPrimaryDisabled}`
                 : "",
             }}
@@ -376,23 +454,22 @@ const SendPraise = () => {
               style={{
                 width: "21px",
                 height: "21px",
-                fill: praiseInfo.hasShuffled
+                fill: praiseInfo.shuffleCount
                   ? `${color.onPrimaryDisabled}`
                   : `${color.onPrimaryActive}`,
               }}
             />
-            이름 셔플 {praiseInfo.hasShuffled ? "1" : "0"}/1
+            이름 셔플 {praiseInfo.shuffleCount}/1
           </ShuffleButton>
           <PraiseMemberContainer>
-            {praiseInfo.members.slice(start, end).map((member, index) => (
+            {praiseInfo.memberList.slice(start, end).map((member, index) => (
               <PraiseMemberWrapper
                 key={index}
                 name={member.name}
-                profileImage={member.profileImage}
-                isChannelAdmin={member.isChannelAdmin}
-                userId={member.userId}
+                profileImageUrl={member.profileImageUrl}
+                memberId={member.memberId}
                 selectedMember={selectedMember}
-                onClick={() => setSelectedMember(member.userId)}
+                onClick={() => setSelectedMember(member.memberId)}
               />
             ))}
           </PraiseMemberContainer>

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -118,7 +118,7 @@ const timerSpanStyle = css`
 `;
 const LoadingDiv = styled.div`
   height: 113px;
-  display: flex:
+  display: flex;
   align-items: center;
 `;
 const spin = keyframes`

--- a/src/pages/ChannelHome.tsx
+++ b/src/pages/ChannelHome.tsx
@@ -23,6 +23,7 @@ interface ChannelProps {
 }
 
 export default function ChannelHome() {
+  const navigate = useNavigate();
   // const channelDummy = [
   //   {
   //     image: exChannel_1,
@@ -40,16 +41,18 @@ export default function ChannelHome() {
 
   const [channelList, setChannelList] = useState<Array<ChannelProps>>();
 
-  const fetchData = async () => {
+  const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  const CONFIG = {
+    headers: {
+      // Authorization: "Bearer " + localStorage.getItem("accessToken"),
+      Authorization:
+        "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI",
+    },
+  };
+
+  const fetchChannelData = async () => {
     try {
-      const res = await axios.get(
-        `${process.env.REACT_APP_SERVER_URL}/channels`,
-        {
-          headers: {
-            Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI`,
-          },
-        }
-      );
+      const res = await axios.get(`${SERVER_URL}/channels`, CONFIG);
       if (res.data && res.data.data) {
         setChannelList(res.data.data as Array<ChannelProps>);
       }
@@ -58,11 +61,18 @@ export default function ChannelHome() {
     }
   };
 
-  useEffect(() => {
-    fetchData();
-  }, []);
+  const handleChannelClick = async (item: any) => {
+    try {
+      localStorage.setItem("memberId", item.memberId);
+      navigate(`/${item.code}/praise`);
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
-  const navigate = useNavigate();
+  useEffect(() => {
+    fetchChannelData();
+  }, []);
 
   return (
     <div>
@@ -111,7 +121,7 @@ export default function ChannelHome() {
           return (
             <div
               key={index}
-              onClick={() => navigate(`/${item.code}/praise`)}
+              onClick={() => handleChannelClick(item)}
               css={ChannelDivStyle}
             >
               <CircularImage image={item.logoImageUrl} size="98" />

--- a/src/pages/ChannelHome.tsx
+++ b/src/pages/ChannelHome.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
-
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Player, Controls } from "@lottiefiles/react-lottie-player";
 import { typography } from "../styles/typography";
 import { color } from "../styles/color";
@@ -11,21 +12,58 @@ import exChannel_2 from "../assets/images/ex-channel-2.png";
 import exChannel_3 from "../assets/images/ex-channel-3.png";
 
 import CircularImage from "../components/CircularImage";
-import { useNavigate } from "react-router-dom";
+import { get } from "../api/api";
+import axios, { AxiosResponse } from "axios";
+
+interface ChannelProps {
+  code: string;
+  id: number;
+  logoImageUrl: string;
+  name: string;
+}
 
 export default function ChannelHome() {
-  const channelDummy = [
-    {
-      image: exChannel_1,
-      name: "모아모아 모아모아 2기",
-    },
-    { image: exChannel_2, name: "롤칼바람나락 good 동아리 3기 good" },
-    { image: exChannel_3, name: "멋쟁이 사자처럼 sdfasfsdfasdfadf fdssadfsafd" },
-    { image: exChannel_1, name: "곰돌이  곰돌이이 adfasdfsfdasfasdfadsfasdd" },
-    { image: exChannel_3, name: "멋쟁이 사자처럼sdfasfsdfasdfadf fdssadfsafd" },
-    { image: exChannel_2, name: "모아모아aasdfasdfasfdsafsafadfafsafadfsaf" },
-  ];
+  // const channelDummy = [
+  //   {
+  //     image: exChannel_1,
+  //     name: "모아모아 모아모아 2기",
+  //   },
+  //   { image: exChannel_2, name: "롤 칼바람 나락 good 동아리 3기 good" },
+  //   {
+  //     image: exChannel_3,
+  //     name: "멋쟁이 사자처럼 12기",
+  //   },
+  //   { image: exChannel_1, name: "곰돌이  곰돌이이 adfasdfsfdasfasdfadsfasdd" },
+  //   // { image: exChannel_3, name: "멋쟁이 사자처럼sdfasfsdfasdfadf fdssadfsafd" },
+  //   // { image: exChannel_2, name: "모아모아aasdfasdfasfdsafsafadfafsafadfsaf" },
+  // ];
+
+  const [channelList, setChannelList] = useState<Array<ChannelProps>>();
+
+  const fetchData = async () => {
+    try {
+      const res = await axios.get(
+        `${process.env.REACT_APP_SERVER_URL}/channels`,
+        {
+          headers: {
+            Authorization: `Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI`,
+          },
+        }
+      );
+      if (res.data && res.data.data) {
+        setChannelList(res.data.data as Array<ChannelProps>);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
   const navigate = useNavigate();
+
   return (
     <div>
       <div
@@ -62,18 +100,21 @@ export default function ChannelHome() {
         style={{
           display: "flex",
           flexWrap: "wrap",
-          gap: "30px 5px",
-          justifyContent: "space-between",
+          gap: "30px 2%",
           padding: "0 20px",
         }}
       >
         <div onClick={() => navigate("/create-channel")} css={ChannelDivStyle}>
           <CircularImage image={btnChannelAdd} size="98" />
         </div>
-        {channelDummy.map((item) => {
+        {channelList?.map((item, index) => {
           return (
-            <div onClick={() => navigate("/praise")} css={ChannelDivStyle}>
-              <CircularImage image={item.image} size="98" />
+            <div
+              key={index}
+              onClick={() => navigate(`/${item.code}/praise`)}
+              css={ChannelDivStyle}
+            >
+              <CircularImage image={item.logoImageUrl} size="98" />
               <div
                 css={css`
                   display: -webkit-box;
@@ -102,10 +143,9 @@ export default function ChannelHome() {
 
 const ChannelDivStyle = css`
   display: flex;
-  flex: calc(33% - 20px);
+  flex: 32%;
   flex-grow: 0;
   flex-direction: column;
-  width: 98px;
   color: ${color.onSurfaceDefault};
   font-size: 14px;
   font-weight: 500;

--- a/src/pages/CreateMeetup.tsx
+++ b/src/pages/CreateMeetup.tsx
@@ -15,6 +15,7 @@ import downArrowMutedIcon from "../assets/icons/ic-downArrowMuted.svg";
 import MeetupImageEditor from "../components/MeetupImageEditor";
 import ButtonBasic from "../components/ButtonBasic";
 import { typography } from "../styles/typography";
+import axios from "axios";
 
 interface MeetupInfoProps {
   title: string;
@@ -37,6 +38,15 @@ const initialMeetupInfo: MeetupInfoProps = {
 };
 
 const CreateMeetup = () => {
+  const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  const CONFIG = {
+    headers: {
+      // Authorization: "Bearer " + localStorage.getItem("accessToken"),
+      Authorization: "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM5MjA3MTAsImV4cCI6MTY5NzUyMDcxMCwic3ViIjoiMSIsIlRPS0VOX1RZUEUiOiJBQ0NFU1NfVE9LRU4ifQ.IT2kHS9XkWMI_Q92nrYmaKHtq8qlb_f55bWqQBP09JI",
+    },
+  };
+  const CHANNEL_ID = localStorage.getItem("channelId");
+
   const [meetupInfo, setMeetupInfo] =
     useState<MeetupInfoProps>(initialMeetupInfo);
 
@@ -72,6 +82,40 @@ const CreateMeetup = () => {
   const handleImageDelete = useCallback(() => {
     setAttachment(null);
   }, []);
+
+  let isPostValid =
+    meetupInfo.title.length > 0 &&
+    meetupInfo.date !== null &&
+    meetupInfo.place !== "" &&
+    meetupInfo.content.length > 0 &&
+    meetupInfo.personNum.length > 0;
+
+  const postNewMeetup = async () => {
+    const partyInfo = {
+      channelId: CHANNEL_ID,
+      title: meetupInfo.title,
+      content: meetupInfo.content,
+      maxCapacity: meetupInfo.personNum,
+      location: meetupInfo.place === undefined? "" : meetupInfo.place,
+      partyDate: meetupInfo.date === undefined ? "" : meetupInfo.date,
+      partyImageUrl: "",
+    };
+    const postResponse = await axios.post(
+      `${SERVER_URL}/party/create`,
+      partyInfo,
+      CONFIG
+    );
+    if (postResponse.status === 200) {
+      console.log(postResponse.data);
+      const res = await axios.get(
+        `${SERVER_URL}/party/list?channelId=${CHANNEL_ID}`,
+        CONFIG
+      );
+      if (res.data) {
+        console.log(res.data);
+      }
+    }
+  };
 
   return (
     <>
@@ -240,8 +284,11 @@ const CreateMeetup = () => {
         <div style={{ width: "calc(100% - 40px)", maxWidth: "460px" }}>
           <ButtonBasic
             innerText="완료"
-            onClick={() => alert("good")}
-            disable={false}
+            onClick={() => {
+              alert("good");
+              postNewMeetup();
+            }}
+            disable={!isPostValid}
           />
         </div>
       </div>
@@ -285,6 +332,7 @@ const undefinedButtonStyle = css`
   width: 82px;
   height: 30px;
   font-family: Pretendard;
+  cursor: pointer;
   font-style: normal;
   font-size: 14px;
   font-weight: 500;

--- a/src/pages/KaKao.tsx
+++ b/src/pages/KaKao.tsx
@@ -4,7 +4,6 @@ import { useEffect } from "react";
 import axios from "axios";
 import { color } from "../styles/color";
 import { useNavigate } from "react-router-dom";
-import { get } from "../api/api";
 
 const KaKao = () => {
   const navigate = useNavigate();
@@ -26,7 +25,7 @@ const KaKao = () => {
             },
           }
         );
-        if (userInfoResponse.data.name) {
+        if (userInfoResponse.data.data.name) {
           navigate("/channel-home");
         } else {
           navigate("/onboarding");

--- a/src/pages/MeetupMember.tsx
+++ b/src/pages/MeetupMember.tsx
@@ -12,26 +12,31 @@ const MeetupMember = () => {
             ></Header>
             <MemberWrapper
                 name="모아이"
+                id={1}
                 image={testUserImg}
                 isChannelAdmin={true}
             />
             <MemberWrapper
                 name="모아이모"
+                id={1}
                 image={testUserImg}
                 isChannelAdmin={false}
             />
             <MemberWrapper
                 name="모아이모아"
+                id={1}
                 image={testUserImg}
                 isChannelAdmin={false}
             />
             <MemberWrapper
                 name="모아이모아이"
+                id={1}
                 image={testUserImg}
                 isChannelAdmin={false}
             />
             <MemberWrapper
                 name="모아이"
+                id={1}
                 image={testUserImg}
                 isChannelAdmin={false}
             />

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import Header from "../components/Header";
 import { color } from "../styles/color";
 import { typography } from "../styles/typography";
+import axios from "axios";
 
 interface OwnProps {
   title: string;
@@ -42,6 +44,18 @@ const NotificationWrapper = ({ title, content, date, isRead }: OwnProps) => {
 };
 
 export default function Notification() {
+  const SERVER_URL = process.env.REACT_APP_SERVER_URL;
+  const CONFIG = {
+    headers: {
+      Authorization: "Bearer " + localStorage.getItem("accessToken"),
+    },
+  };
+  // const [notifications, setNotifications] = useState([]);
+
+  // const fetchNotifications = async () => {
+  //   const notificationResponse = await axios.get(`${SERVER_URL}/api/notifications`, CONFIG);
+  // };
+
   return (
     <>
       <Header type="back" />

--- a/src/pages/Notification.tsx
+++ b/src/pages/Notification.tsx
@@ -50,11 +50,18 @@ export default function Notification() {
       Authorization: "Bearer " + localStorage.getItem("accessToken"),
     },
   };
-  // const [notifications, setNotifications] = useState([]);
+  const USER_ID = localStorage.getItem("userId");
 
-  // const fetchNotifications = async () => {
-  //   const notificationResponse = await axios.get(`${SERVER_URL}/api/notifications`, CONFIG);
-  // };
+  const [notifications, setNotifications] = useState();
+
+  const fetchNotifications = async () => {
+    const notificationResponse = await axios.get(
+      `${SERVER_URL}/notification/member/${USER_ID}`,
+      CONFIG
+    );
+    console.log(notificationResponse.data);
+  };
+  fetchNotifications();
 
   return (
     <>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,5 +1,4 @@
 import react, { useState } from "react";
-
 import { typography } from "../styles/typography";
 import { color } from "../styles/color";
 import InputText from "../components/InputText";
@@ -8,6 +7,7 @@ import DatePicker from "../components/DatePicker";
 import ButtonBasic from "../components/ButtonBasic";
 import { useNavigate } from "react-router-dom";
 import Header from "../components/Header";
+import { put } from "../api/api";
 
 export default function Onboarding() {
   const navigate = useNavigate();
@@ -23,6 +23,32 @@ export default function Onboarding() {
 
   let checkOnboarding = !(name && gender);
 
+  const postOnboarding = async () => {
+    try {
+      const formatDate = (dateString: string) => {
+        return dateString.replace(/\./g, '-');
+      }
+      const data = {
+        name: name,
+        gender: gender === "남자" ? "MAN" : "WOMAN",
+        birthDate: formatDate(birthDate),
+      };
+      console.log(data);
+      const onboardingRes = await put(
+        "/users/update",
+        data,
+        `${localStorage.getItem("accessToken")}`
+      );
+      if (onboardingRes instanceof Error) {
+        console.error("Error: ", onboardingRes);
+      } else {
+        console.log("Data: ", onboardingRes.data);
+        navigate("/channel-home");
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
   return (
     <>
       <Header type="back" />
@@ -36,7 +62,6 @@ export default function Onboarding() {
             flexDirection: "column",
             flexShrink: "0",
             justifyContent: "center",
-
             marginBottom: "40px",
           }}
         >
@@ -72,12 +97,14 @@ export default function Onboarding() {
             label="생년월일"
             placeholder="생년월일을 선택해 주세요."
             value={birthDate}
+            birthDate={birthDate}
+            setBirthDate={setBirthDate}
           />
         </section>
         <ButtonBasic
           innerText="확인"
           disable={checkOnboarding}
-          onClick={() => navigate("/channel-home")}
+          onClick={postOnboarding}
         />
       </div>
     </>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -33,7 +33,6 @@ export default function Onboarding() {
         gender: gender === "남자" ? "MAN" : "WOMAN",
         birthDate: formatDate(birthDate),
       };
-      console.log(data);
       const onboardingRes = await put(
         "/users/update",
         data,
@@ -42,7 +41,6 @@ export default function Onboarding() {
       if (onboardingRes instanceof Error) {
         console.error("Error: ", onboardingRes);
       } else {
-        console.log("Data: ", onboardingRes.data);
         navigate("/channel-home");
       }
     } catch (error) {

--- a/src/pages/Praise.tsx
+++ b/src/pages/Praise.tsx
@@ -213,21 +213,19 @@ const Praise = () => {
   };
 
   const fetchChannelIdAndValidity = async () => {
-    let channelId;
     try {
       const infoResponse = await axios.get(
         `${SERVER_URL}/channels/info?code=${channelCode}`,
         CONFIG
       );
       if (infoResponse.data && infoResponse.data.data) {
-        channelId = infoResponse.data.data.id;
+        const channelId = infoResponse.data.data.id;
         localStorage.setItem("channelId", channelId);
         const validityResponse = await axios.get(
           `${SERVER_URL}/channels/${channelId}/validity`,
           CONFIG
         );
         if (validityResponse.data) {
-          console.log(validityResponse.data.data)
           if (validityResponse.data.data.isValid === true) {
             setIsChannelActive(true);
           } else {
@@ -264,12 +262,12 @@ const Praise = () => {
           isSelected={selectedCategory === 3}
           onClick={handleCategory3Click}
         />
-        <CategoryBtn
+        {/* <CategoryBtn
           onClick={() => setIsChannelActive((prev) => !prev)}
           style={{ background: isChannelActive ? `${color.primary500}` : "" }}
         >
           {isChannelActive ? "on" : "off"}
-        </CategoryBtn>
+        </CategoryBtn> */}
       </CategoryContainer>
       {selectedCategory === 1 ? (
         isChannelActive ? (


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
카카오 로그인, 온보딩, 채널홈, 칭찬, 멤버리스트 페이지 api 연동


## 작업 내용 (변경 사항)
로그인 후 accessToken과 refreshToken을 localstorage에 저장하고
채널홈에서 특정채널로 입장시 해당 채널 id와 해당 채널에서의 나의 member id를 localStorage에 저장
칭찬 페이지는 페이지네이션을 제외하고 구현완료
멤버리스트 페이지는 무한 스크롤과 검색기능 제외하고 구현완료

## 리뷰 요청 사항
