### PR TITLE
Feat: 라우터 내에서 헤더 Layout 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Routes, Route } from "react-router-dom";
 import Login from "./pages/Login";
 import CreateChannel from "./pages/CreateChannel";
@@ -28,74 +27,65 @@ import KaKao from "./pages/KaKao";
 import CheckChannelCode from "./pages/CheckChannelCode";
 import NotFound from "./pages/NotFound";
 import Error400 from "./pages/Error400";
+import CommonHeaderLayout from "./CommonHeaderLayout";
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Login />}></Route>
-      <Route path="/oauth/callback/kakao" element={<KaKao />}></Route>
-      <Route path="/onboarding" element={<Onboarding />}></Route>
-      <Route path="/channel-home" element={<ChannelHome />}></Route>
-      <Route path="/create-channel" element={<CreateChannel />}></Route>
+      <Route path="/" element={<Login />} />
+      <Route path="/oauth/callback/kakao" element={<KaKao />} />
+      <Route path="/onboarding" element={<Onboarding />} />
+      <Route path="/channel-home" element={<ChannelHome />} />
+      <Route path="/create-channel" element={<CreateChannel />} />
       <Route
         path="/create-channel/new-onboarding"
         element={<NewChannelOnboarding />}
-      ></Route>
+      />
       <Route
         path="/create-channel/old-onboarding"
         element={<OldChannelOnboarding />}
-      ></Route>
-      <Route path="/:channelCode" element={<CheckChannelCode />}></Route>
-      <Route path="/:channelCode/praise" element={<Praise />}></Route>
-      <Route path="/:channelCode/member-list" element={<MemberList />}></Route>
-      <Route
-        path="/:channelCode/notification"
-        element={<Notification />}
-      ></Route>
-      <Route
-        path="/:channelCode/create-meetup"
-        element={<CreateMeetup />}
-      ></Route>
+      />
+      <Route path="/:channelCode" element={<CheckChannelCode />} />
+      <Route element={<CommonHeaderLayout />}>
+        <Route path="/:channelCode/praise" element={<Praise />} />
+        <Route path="/:channelCode/member-list" element={<MemberList />} />
+        <Route path="/:channelCode/meetup-home" element={<MeetupHome />} />
+      </Route>
+      <Route path="/:channelCode/notification" element={<Notification />} />
+      <Route path="/:channelCode/create-meetup" element={<CreateMeetup />} />
       <Route
         path="/:channelCode/edit-meetup/:meetupId"
         element={<EditMeetup />}
-      ></Route>
+      />
       <Route
         path="/:channelCode/modify-channel-info"
         element={<ModifyChannelInfo />}
-      ></Route>
-      <Route path="/:channelCode/meetup-home" element={<MeetupHome />}></Route>
+      />
       <Route
         path="/:channelCode/meetup-detail/:meetupId"
         element={<MeetupDetail />}
-      ></Route>
+      />
       <Route
         path="/:channelCode/meetup-member/:meetupId"
         element={<MeetupMember />}
-      ></Route>
+      />
       <Route
         path="/:channelCode/create-card/:meetupId"
         element={<CreateCard />}
-      ></Route>
-      <Route
-        path="/:channelCode/comment/:meetupId"
-        element={<Comment />}
-      ></Route>
-      <Route path="/:channelCode/mypage" element={<Mypage />}></Route>
+      />
+      <Route path="/:channelCode/comment/:meetupId" element={<Comment />} />
+      <Route path="/:channelCode/mypage" element={<Mypage />} />
       <Route
         path="/:channelCode/memberpage/:memberId"
         element={<Memberpage />}
-      ></Route>
-      <Route path="/:channelCode/my-meetup" element={<MyMeetup />}></Route>
-      <Route
-        path="/modify-profile-info"
-        element={<ModifyProfileInfo />}
-      ></Route>
-      <Route path="/point" element={<PointDetail />}></Route>
-      <Route path="/:channelCode/album/:memberId" element={<Album />}></Route>
-      <Route path="/error-400" element={<Error400 />}></Route>
-      <Route path="/error-404" element={<NotFound />}></Route>
-      <Route path="/*" element={<NotFound />}></Route>
+      />
+      <Route path="/:channelCode/my-meetup" element={<MyMeetup />} />
+      <Route path="/modify-profile-info" element={<ModifyProfileInfo />} />
+      <Route path="/point" element={<PointDetail />} />
+      <Route path="/:channelCode/album/:memberId" element={<Album />} />
+      <Route path="/error-400" element={<Error400 />} />
+      <Route path="/error-404" element={<NotFound />} />
+      <Route path="/*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/src/CommonHeaderLayout.tsx
+++ b/src/CommonHeaderLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router-dom";
+import Header from "./components/Header";
+
+const CommonHeaderLayout = () => {
+  return (
+    <>
+      <Header type="common" />
+      <Outlet />
+    </>
+  );
+};
+
+export default CommonHeaderLayout;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -57,6 +57,7 @@ const Header = ({
   const [sidebarState, setSidebarState] = useState<number>(0);
   const [channelInfo, setChannelInfo] = useState<ChannelInfoProps | null>(null);
   const [noticeInfo, setNoticeInfo] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     if (type === "common") {
@@ -98,6 +99,7 @@ const Header = ({
 
   const getChannelInfo = async () => {
     try {
+      setIsLoading(true);
       await axios
         .get(`${SERVER_URL}/channels/info?code=${channelCode}`, CONFIG)
         .then((res) => {
@@ -106,6 +108,7 @@ const Header = ({
             .get(`${SERVER_URL}/channels/${CHANNEL_ID}`, CONFIG)
             .then((res) => {
               setChannelInfo(res.data.data);
+              setIsLoading(false);
             });
         });
       axios
@@ -191,20 +194,33 @@ const Header = ({
               width: "calc(100vw - 140px)",
             }}
           >
-            <CircularImage
-              size="24"
-              image={channelInfo !== null ? channelInfo.logoImageUrl : ""}
-            />
-            <span
-              style={{
-                marginLeft: "10px",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {channelInfo !== null ? channelInfo.name : ""}
-            </span>
+            {isLoading ? (
+              <div
+                style={{
+                  width: "24px",
+                  height: "24px",
+                  backgroundColor: "lightgray",
+                  borderRadius: "50%",
+                }}
+              />
+            ) : (
+              <>
+                <CircularImage
+                  size="24"
+                  image={channelInfo !== null ? channelInfo.logoImageUrl : ""}
+                />
+                <span
+                  style={{
+                    marginLeft: "10px",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {channelInfo !== null ? channelInfo.name : ""}
+                </span>
+              </>
+            )}
           </div>
           <div
             style={{

--- a/src/components/TokenRefresh.tsx
+++ b/src/components/TokenRefresh.tsx
@@ -44,7 +44,6 @@ const TokenRefresh = () => {
   };
 
   useEffect(() => {
-    console.log(location.pathname);
     if (!ACCESS_TOKEN) {
       if (
         location.pathname !== "/oauth/callback/kakao" &&

--- a/src/pages/MeetupHome.tsx
+++ b/src/pages/MeetupHome.tsx
@@ -145,7 +145,6 @@ const MeetupHome = () => {
 
   return (
     <>
-      <Header type="common" />
       {loading && (
         <div
           style={{

--- a/src/pages/MemberList.tsx
+++ b/src/pages/MemberList.tsx
@@ -163,7 +163,6 @@ export default function MemberList() {
 
   return (
     <>
-      <Header type="common" />
       <div style={{ padding: "0 20px", margin: "8px 0 4px 0" }}>
         <SearchWrapper>
           <img

--- a/src/pages/Praise.tsx
+++ b/src/pages/Praise.tsx
@@ -252,7 +252,6 @@ const Praise = () => {
 
   return (
     <>
-      <Header type="common" />
       <CategoryContainer>
         <CategoryWrapper
           categoryName="칭찬보내기"


### PR DESCRIPTION
칭찬, 모임, 멤버 모두 common type 헤더를 사용하는데
페이지를 옮길 때마다 새로 렌더링하여 이미지 로딩이 생기는 문제 해결
이미지 로딩 중에 skeleton ui 적용 -> 채널 로고 이미지 부분 회색 원 추가

## 작업 개요 (이슈 번호)


## 작업 내용 (변경 사항)


## 리뷰 요청 사항
