### PR TITLE
Hotfix: 모임 카드 만들기 완료 시 버튼 로딩 상태 추가

### DIFF
--- a/src/pages/CreateCard.tsx
+++ b/src/pages/CreateCard.tsx
@@ -25,9 +25,11 @@ const CreateCard = () => {
   const [memberState, setMemberState] = useState<boolean>(false);
   const [meetupData, setMeetupData] = useState<any>();
   const [popupState, setPopupState] = useState<boolean>(false);
+  const [loadState, setLoadState] = useState<boolean>(false);
 
   const handleCardMakingBtnClick = async () => {
     try {
+      setLoadState(true);
       if (cardImageFile !== null) {
         const cardImgFormData = new FormData();
         cardImgFormData.append("image", cardImageFile);
@@ -55,7 +57,10 @@ const CreateCard = () => {
         }
       }
     } catch (err) {
+      alert("사진 업로드 중 오류가 발생했습니다. 다시 시도해주세요.");
       console.error(err);
+    } finally {
+      setLoadState(false);
     }
   };
 
@@ -261,7 +266,7 @@ const CreateCard = () => {
         <>
           <Header
             type={cardState ? "card" : "back"}
-            text="카드 만들기"
+            text='카드 만들기'
             downloadFunc={handleDownloadImgClick}
             func={handleParticipantImgClick}
           ></Header>
@@ -277,18 +282,18 @@ const CreateCard = () => {
                 />
                 <div style={{ height: "39px" }}></div>
                 <ButtonBasic
-                  innerText="확인"
+                  innerText='확인'
                   onClick={handleConfirmBtnClick}
                   disable={false}
                 ></ButtonBasic>
                 <canvas ref={canvasRef} style={{ display: "none" }}></canvas>
                 {popupState && (
                   <Popup1
-                    title="저장 완료"
+                    title='저장 완료'
                     text={
                       "카드에 있는 텍스트는 제외하고\n모임 날짜만 함께 저장했어요"
                     }
-                    btnText="확인"
+                    btnText='확인'
                     func={() => setPopupState(false)}
                   />
                 )}
@@ -307,7 +312,7 @@ const CreateCard = () => {
                   }}
                 >
                   <label
-                    htmlFor="ex_file"
+                    htmlFor='ex_file'
                     style={{
                       width: "100%",
                       height: "100%",
@@ -385,10 +390,10 @@ const CreateCard = () => {
                         clip: "rect(0, 0, 0, 0)",
                         border: "0",
                       }}
-                      type="file"
-                      id="ex_file"
-                      name="cardImage"
-                      accept="image/*"
+                      type='file'
+                      id='ex_file'
+                      name='cardImage'
+                      accept='image/*'
                       onChange={handleCardImageUpload}
                     />
                     <canvas
@@ -399,9 +404,9 @@ const CreateCard = () => {
                 </div>
                 <div style={{ height: "39px" }}></div>
                 <ButtonBasic
-                  innerText="카드 만들기 완료"
+                  innerText={loadState ? "업로드 중..." : "카드 만들기 완료"}
                   onClick={handleCardMakingBtnClick}
-                  disable={cardImage === undefined}
+                  disable={cardImage === undefined || loadState === true}
                 ></ButtonBasic>
               </>
             )}

--- a/src/pages/MemberList.tsx
+++ b/src/pages/MemberList.tsx
@@ -120,7 +120,7 @@ export default function MemberList() {
   const [cursorId, setCursorId] = useState<number>(0);
   const [cursorName, setCursorName] = useState<string>("");
   const [hasMore, setHasMore] = useState<boolean>(true);
-  const SIZE = 15;
+  const SIZE = 20;
   const [loading, setLoading] = useState<boolean>(false);
   const [searchWord, setSearchWord] = useState<string>("");
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/ranking/RankingItem.tsx
+++ b/src/pages/ranking/RankingItem.tsx
@@ -4,6 +4,7 @@ import { color } from "../../styles/color";
 import RankIcon from "../../images/rankPointIcon.svg";
 import { RankingType } from "../../apis/ranking";
 import { 세자리콤마추가 } from "../../utils/addCommas";
+import { useNavigate, useParams } from "react-router-dom";
 
 export function RankingItem({
   memberId,
@@ -12,8 +13,19 @@ export function RankingItem({
   nickname,
   point,
 }: RankingType) {
+  const navigate = useNavigate();
+  const { channelCode } = useParams();
+  const myMemberId = Number(localStorage.getItem("memberId"));
+  const navigateToMyPage = () => {
+    if (memberId === myMemberId) {
+      navigate(`/${channelCode}/mypage`);
+    } else {
+      navigate(`/${channelCode}/memberpage/${memberId}`);
+    }
+  };
+
   return (
-    <ItemContainer>
+    <ItemContainer onClick={navigateToMyPage}>
       <div className='item-left-section'>
         <h4>{rank}</h4>
         <RankProfileImage rank={rank} image={userProfileImage} />
@@ -35,6 +47,8 @@ const ItemContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  cursor: pointer;
 
   .item-left-section {
     display: flex;


### PR DESCRIPTION
모임 완료 후 카드 만들기 페이지에서 사진 업로드 확인 버튼을 여러번 클릭 시 /party/finish api를 여러번 호출함 따라서 점수와 블럭 개수에 문제가 생겼음
api 통신을 하는 동안 로딩상태를 추가하고 버튼 disable 상태로 전환

추가로 랭킹페이지에서 유저 클릭시 유저 페이지 혹은 본인의 페이지로 이동가능 하게 추가

## 작업 개요 (이슈 번호)


## 작업 내용 (변경 사항)


## 리뷰 요청 사항
